### PR TITLE
Add event listener in steps

### DIFF
--- a/applauncher/applauncher.py
+++ b/applauncher/applauncher.py
@@ -108,7 +108,9 @@ class Kernel:
         """Add bundles' event listeners"""
         registered_listeners = []
         for event_type, listener in getattr(bundle, 'event_listeners', []):
-            if config_only and not issubclass(event_type, ConfigurationReadyEvent):
+            is_config_event = issubclass(event_type, ConfigurationReadyEvent)
+            must_register = is_config_event if config_only else not is_config_event
+            if not must_register:
                 continue
             self.event_manager.add_listener(event=event_type, listener=listener)
             registered_listeners.append(event_type)

--- a/applauncher/configuration.py
+++ b/applauncher/configuration.py
@@ -1,4 +1,5 @@
 """Configuration format loaders"""
+import locale
 import os
 from abc import ABC, abstractmethod
 import yaml
@@ -46,7 +47,7 @@ class YmlLoader(ConfigurationLoader):
     """YML Format parser and config loader"""
     def load_parameters(self, source):
         """For YML, the source it the file path"""
-        with open(source) as parameters_source:
+        with open(source, encoding=locale.getpreferredencoding(False)) as parameters_source:
             loaded = yaml.safe_load(parameters_source.read())
             if loaded:
                 for key, value in loaded.items():
@@ -57,7 +58,7 @@ class YmlLoader(ConfigurationLoader):
 
     def load_config(self, config_source, parameters_source):
         """For YML, the source it the file path"""
-        with open(config_source) as config_source_file:
+        with open(config_source, encoding=locale.getpreferredencoding(False)) as config_source_file:
             config_raw = config_source_file.read()
 
             parameters = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "applauncher"
-version = "2.0.2"
+version = "2.1.0"
 description = "Python application launcher"
 authors = ["Alvaro Garcia <maxpowel@gmail.com>"]
 license = "Apache"

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,30 @@
 [tox]
-envlist = py36
+envlist = py36,py37,py38,py39
 skipsdist = True
 
 [testenv]
 setenv = PYTHONPATH = {toxinidir}
+allowlist_externals =
+    rm
+
 deps =
-   -r{toxinidir}/requirements.txt
+   poetry
    pytest
    pytest-cov
    flake8
    pylint
 
+commands_pre =
+    poetry config virtualenvs.create false --local
+    poetry config virtualenvs.path {toxinidir}/.tox --local
+    poetry install -q
+
 commands =
     flake8 --max-line-length 120 applauncher
     pylint --max-line-length=120 --disable too-few-public-methods applauncher --extension-pkg-whitelist=pydantic,dependency_injector
     pytest --cov=applauncher --cov-fail-under=100
+
+commands_post =
+    poetry config virtualenvs.create --unset --local
+    poetry config virtualenvs.path --unset --local
+    rm poetry.toml


### PR DESCRIPTION
Add event listeners in two steps so config event can change them.

Firstly, load all ConfigurationReadyEvent listeners and run them once the configuration is ready. Afterwards, load all other event listeners so they can be run.

The goal of this change is to be able to dynamically edit a bundle's event_listeners attribute after the Configuration is ready.
In other words, for a ConfigurationReadyEvent listener to be able to add extra listeners that will be run for other events.


For example:

**bundle.py**
```
class MyBundle:
    def __init__(self):
        self.event_listeners = [(ConfigurationReadyEvent, self.on_config_ready)]

    def on_config_ready(self, event):
        for event_type, listener in event.configuration.my_bundle.event_listeners.items():
            event_type = import_from_path(event_type)
            listener = import_from_path(listener)
            self.event_listeners.append((event_type, listener))
```

**config/config.yml**
```
my_bundle:
  event_listeners:
    "applauncher.event:KernelReadyEvent": "my_bundle.event_listeners:kernel_ready_listener"
    "some_other_package.event:SomeEvent": "yet_another_package.event_listeners:some_event_listener"
```